### PR TITLE
Fix plugin schema version at 1

### DIFF
--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<go-plugin id="healthcheck.task.plugin" version="${version}">
+<go-plugin id="healthcheck.task.plugin" version="1">
     <about>
         <name>Health Check Task Plugin</name>
         <version>${version}</version>


### PR DESCRIPTION
This attribute is a plugin schema version and it should be fixed at "1" currently. This [upcoming PR](https://github.com/gocd/gocd/pull/2062) will make this plugin fail, without this change.
